### PR TITLE
Fix deprecated topic strings on ios. Implement revokeToken()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ cordova.plugins.firebase.messaging.getToken().then(function(token) {
 });
 ```
 
+### revokeToken
+Delete the Instance ID (Token) and the data associated with it.
+Call getToken to generate a new one.
+```js
+cordova.plugins.firebase.messaging.revokeToken().then(function() {
+    console.log("Token revoked successfully");
+});
+```
+
 ### onTokenRefresh(_callback_)
 Triggers every time when FCM token updated. You should usually call `getToken` to get an updated token and send it to server.
 ```js

--- a/src/android/FirebaseMessagingPlugin.java
+++ b/src/android/FirebaseMessagingPlugin.java
@@ -81,6 +81,21 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
     }
 
     @CordovaMethod
+    private void revokeToken(final CallbackContext callbackContext) {
+        FirebaseInstanceId.getInstance().deleteInstanceId()
+            .addOnCompleteListener(cordova.getActivity(), new OnCompleteListener<InstanceIdResult>() {
+                @Override
+                public void onComplete(Task<InstanceIdResult> task) {
+                    if (task.isSuccessful()) {
+                        callbackContext.success();
+                    } else {
+                        callbackContext.error(task.getException().getMessage());
+                    }
+                }
+            });
+    }
+
+    @CordovaMethod
     private void getToken(final CallbackContext callbackContext) {
         FirebaseInstanceId.getInstance().getInstanceId()
             .addOnCompleteListener(cordova.getActivity(), new OnCompleteListener<InstanceIdResult>() {

--- a/src/ios/FirebaseMessagingPlugin.h
+++ b/src/ios/FirebaseMessagingPlugin.h
@@ -4,6 +4,7 @@
 
 @interface FirebaseMessagingPlugin : CDVPlugin<FIRMessagingDelegate>
 - (void)requestPermission:(CDVInvokedUrlCommand*)command;
+- (void)revokeToken:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;
 - (void)setBadge:(CDVInvokedUrlCommand*)command;
 - (void)getBadge:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -78,6 +78,18 @@
     [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 
+- (void)revokeToken:(CDVInvokedUrlCommand *)command {
+    [[FIRInstanceID instanceID] deleteIDWithHandler:^(NSError *  _Nullable error) {
+        CDVPluginResult *pluginResult;
+        if (error) {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
+        } else {
+            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+        }
+        [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
+}
+
 - (void)getToken:(CDVInvokedUrlCommand *)command {
     NSString *fcmToken = [FIRMessaging messaging].FCMToken;
     if (fcmToken) {

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -114,7 +114,7 @@
 }
 
 - (void)subscribe:(CDVInvokedUrlCommand *)command {
-    NSString* topic = [NSString stringWithFormat:@"/topics/%@", [command.arguments objectAtIndex:0]];
+    NSString* topic = [NSString stringWithFormat:@"%@", [command.arguments objectAtIndex:0]];
 
     [[FIRMessaging messaging] subscribeToTopic:topic
                                     completion:^(NSError * _Nullable error) {
@@ -129,7 +129,7 @@
 }
 
 - (void)unsubscribe:(CDVInvokedUrlCommand *)command {
-    NSString* topic = [NSString stringWithFormat:@"/topics/%@", [command.arguments objectAtIndex:0]];
+    NSString* topic = [NSString stringWithFormat:@"%@", [command.arguments objectAtIndex:0]];
 
     [[FIRMessaging messaging] unsubscribeFromTopic:topic
                                         completion:^(NSError * _Nullable error) {

--- a/www/FirebaseMessaging.js
+++ b/www/FirebaseMessaging.js
@@ -22,6 +22,11 @@ module.exports = {
     onBackgroundMessage: function(callack, error) {
         exec(callack, error, PLUGIN_NAME, "onBackgroundMessage", []);
     },
+    revokeToken: function() {
+        return new Promise(function(resolve, reject) {
+            exec(resolve, reject, PLUGIN_NAME, "revokeToken", []);
+        });
+    },
     getToken: function() {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "getToken", []);


### PR DESCRIPTION
Fix deprecated topic strings on ios
--
As of Version 5.2.0 - Jun 6, 2018 the format of topics was changed resulting in the following deprecation warning:

``` 
[Firebase/Messaging][I-FCM002024] Format '/topics/all' is deprecated. Only 'all' should be used in subscribeToTopic

[Firebase/Messaging][I-FCM002024] Format '/topics/all' is deprecated. Only 'all' should be used in unsubscribeToTopic
```

Implement revokeToken()
--
Closes #33 

### revokeToken
Delete the Instance ID (Token) and the data associated with it.
Call getToken to generate a new one.
```js
cordova.plugins.firebase.messaging.revokeToken().then(function() {
    console.log("Token revoked successfully");
});
```