### PR TITLE
Avoid exception by checking for apns token, throw error message instead

### DIFF
--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -182,7 +182,7 @@
             NSData* deviceToken = [FIRMessaging messaging].APNSToken;
 
             if (deviceToken == nil) {
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Could not retrieve APNS token"];
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: NULL];
             } else {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:deviceToken];
             }

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -180,7 +180,12 @@
             pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:error.localizedDescription];
         } else {
             NSData* deviceToken = [FIRMessaging messaging].APNSToken;
-            pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:deviceToken];
+
+            if (deviceToken == nil) {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Could not retrieve APNS token"];
+            } else {
+                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:deviceToken];
+            }
         }
         [self.commandDelegate sendPluginResult:pluginResult callbackId:self.registerCallbackId];
     }


### PR DESCRIPTION
This pull-request provides a solution for the problem issued in #32.

My solution checks if the retrieved APNS token is nil, if so the error callback is thrown with the message "Could not retrieve APNS token".