### PR TITLE
Add an "autoHide" option to disable automatically hiding notification

### DIFF
--- a/src/android/FirebaseMessagingPlugin.java
+++ b/src/android/FirebaseMessagingPlugin.java
@@ -35,6 +35,7 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
     private JSONObject lastBundle;
     private boolean isBackground = false;
     private boolean forceShow = false;
+    private boolean autoHide = true;
     private CallbackContext tokenRefreshCallback;
     private CallbackContext foregroundCallback;
     private CallbackContext backgroundCallback;
@@ -152,6 +153,7 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
         Context context = cordova.getActivity().getApplicationContext();
 
         this.forceShow = options.optBoolean("forceShow");
+        this.autoHide = options.optBoolean("autoHide", this.autoHide);
 
         if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
             callbackContext.success();
@@ -219,6 +221,10 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
 
     static boolean isForceShow() {
         return instance != null && instance.forceShow;
+    }
+
+    static boolean isAutoHide() {
+        return instance != null && instance.autoHide;
     }
 
     private void sendNotification(JSONObject notificationData, CallbackContext callbackContext) {

--- a/src/android/FirebaseMessagingPluginService.java
+++ b/src/android/FirebaseMessagingPluginService.java
@@ -88,13 +88,16 @@ public class FirebaseMessagingPluginService extends FirebaseMessagingService {
         builder.setPriority(1);
 
         this.notificationManager.notify(0, builder.build());
-        // dismiss notification to hide icon from status bar automatically
-        new Handler(getMainLooper()).postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                notificationManager.cancel(0);
-            }
-        }, 3000);
+
+        if (FirebaseMessagingPlugin.isAutoHide()) {
+            // dismiss notification to hide icon from status bar automatically
+            new Handler(getMainLooper()).postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    notificationManager.cancel(0);
+                }
+            }, 3000);
+        }
     }
 
     private Uri getNotificationSound(String soundName) {


### PR DESCRIPTION
  - Defaults to true (preserves existing functionality)
  - When set to false notifications received in the foreground will not
    be automatically hidden after three seconds