### PR TITLE
iOS 13: APNS token is no longer accessible via description property

### DIFF
--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -78,8 +78,17 @@
             if ([type isEqualToString:@"apns-buffer"]) {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArrayBuffer:apnsToken];
             } else if ([type isEqualToString:@"apns-string"]) {
-                NSString* hexToken = [[apnsToken.description componentsSeparatedByCharactersInSet:[[NSCharacterSet alphanumericCharacterSet]invertedSet]]componentsJoinedByString:@""];
-                pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:hexToken];
+                NSUInteger length = apnsToken.length;
+                if (length == 0) {
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"APNS token not found"];
+                } else {
+                    const unsigned char *buffer = apnsToken.bytes;
+                    NSMutableString *hexString  = [NSMutableString stringWithCapacity:(length * 2)];
+                    for (int i = 0; i < length; ++i) {
+                        [hexString appendFormat:@"%02x", buffer[i]];
+                    }
+                    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:[hexString copy]];
+                }
             } else {
                 pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Invalid APNS token type argument"];
             }


### PR DESCRIPTION
As of iOS 13, `cordova-plugin-firebase-messaging` will serve up a garbage string when calling `getToken('apns-string')`.

This fix is adapted from https://onesignal.com/blog/ios-13-introduces-4-breaking-changes-to-notifications/