### PR TITLE
Change podspec source to cocoapods cdn

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -47,7 +47,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <podspec>
             <config>
-                <source url="https://github.com/CocoaPods/Specs.git"/>
+                <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
                 <pod name="Firebase/Analytics" spec="~> 6.3.0" />


### PR DESCRIPTION
Original podspec url (before change) caused conflicts when installing number of plugins from various sources.