### PR TITLE
Fixes #57

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,10 @@ cordova.plugins.firebase.messaging.getToken("apns-string").then(function(token) 
 });
 ```
 
-### clearMessages
-Clear all notification messages from system notification bar.
+### clearNotifications
+Clear all notifications from system notification bar.
 ```js
-cordova.plugins.firebase.messaging.clearMessages(function() {
+cordova.plugins.firebase.messaging.clearNotifications(function() {
     console.log("Notification messages cleared successfully");
 });
 ```

--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ cordova.plugins.firebase.messaging.getToken("apns-string").then(function(token) 
 });
 ```
 
+### clearMessages
+Clear all notification messages from system notification bar.
+```js
+cordova.plugins.firebase.messaging.clearMessages(function() {
+    console.log("Notification messages cleared successfully");
+});
+```
+
 ### revokeToken
 Delete the Instance ID (Token) and the data associated with it.
 Call getToken to generate a new one.

--- a/src/android/FirebaseMessagingPlugin.java
+++ b/src/android/FirebaseMessagingPlugin.java
@@ -90,7 +90,6 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
 
     @CordovaMethod
     private void clearMessages(CallbackContext callbackContext) throws IOException {
-        // NotificationManager nMgr = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager = getSystemService(cordova.getActivity(), NotificationManager.class);
         notificationManager.cancelAll();
 

--- a/src/android/FirebaseMessagingPlugin.java
+++ b/src/android/FirebaseMessagingPlugin.java
@@ -89,7 +89,7 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
     }
 
     @CordovaMethod
-    private void clearMessages(CallbackContext callbackContext) throws IOException {
+    private void clearNotifications(CallbackContext callbackContext) throws IOException {
         notificationManager = getSystemService(cordova.getActivity(), NotificationManager.class);
         notificationManager.cancelAll();
 

--- a/src/android/FirebaseMessagingPlugin.java
+++ b/src/android/FirebaseMessagingPlugin.java
@@ -89,6 +89,15 @@ public class FirebaseMessagingPlugin extends ReflectiveCordovaPlugin {
     }
 
     @CordovaMethod
+    private void clearMessages(CallbackContext callbackContext) throws IOException {
+        // NotificationManager nMgr = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+        notificationManager = getSystemService(cordova.getActivity(), NotificationManager.class);
+        notificationManager.cancelAll();
+
+        callbackContext.success();
+    }
+
+    @CordovaMethod
     private void revokeToken(CallbackContext callbackContext) throws IOException {
         FirebaseInstanceId.getInstance().deleteInstanceId();
 

--- a/src/ios/FirebaseMessagingPlugin.h
+++ b/src/ios/FirebaseMessagingPlugin.h
@@ -4,7 +4,7 @@
 
 @interface FirebaseMessagingPlugin : CDVPlugin
 - (void)requestPermission:(CDVInvokedUrlCommand*)command;
-- (void)clearMessages:(CDVInvokedUrlCommand*)command;
+- (void)clearNotifications:(CDVInvokedUrlCommand*)command;
 - (void)revokeToken:(CDVInvokedUrlCommand*)command;
 - (void)getInstanceId:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebaseMessagingPlugin.h
+++ b/src/ios/FirebaseMessagingPlugin.h
@@ -4,6 +4,7 @@
 
 @interface FirebaseMessagingPlugin : CDVPlugin
 - (void)requestPermission:(CDVInvokedUrlCommand*)command;
+- (void)clearMessages:(CDVInvokedUrlCommand*)command;
 - (void)revokeToken:(CDVInvokedUrlCommand*)command;
 - (void)getInstanceId:(CDVInvokedUrlCommand*)command;
 - (void)getToken:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -36,6 +36,12 @@
     [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 
+- (void)clearMessages:(CDVInvokedUrlCommand *)command {
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center removeAllDeliveredNotifications];
+    [center removeAllPendingNotificationRequests];
+}
+
 - (void)revokeToken:(CDVInvokedUrlCommand *)command {
     [[FIRInstanceID instanceID] deleteIDWithHandler:^(NSError* err) {
         CDVPluginResult *pluginResult;

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -40,6 +40,8 @@
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     [center removeAllDeliveredNotifications];
     [center removeAllPendingNotificationRequests];
+    CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 - (void)revokeToken:(CDVInvokedUrlCommand *)command {

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -36,10 +36,9 @@
     [[UIApplication sharedApplication] registerForRemoteNotifications];
 }
 
-- (void)clearMessages:(CDVInvokedUrlCommand *)command {
+- (void)clearNotifications:(CDVInvokedUrlCommand *)command {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
     [center removeAllDeliveredNotifications];
-    [center removeAllPendingNotificationRequests];
     CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }

--- a/www/FirebaseMessaging.js
+++ b/www/FirebaseMessaging.js
@@ -22,6 +22,9 @@ module.exports = {
     onBackgroundMessage: function(callack, error) {
         exec(callack, error, PLUGIN_NAME, "onBackgroundMessage", []);
     },
+    clearMessages: function(callack, error) {
+        exec(callack, error, PLUGIN_NAME, "clearMessages", []);
+    },
     revokeToken: function() {
         return new Promise(function(resolve, reject) {
             exec(resolve, reject, PLUGIN_NAME, "revokeToken", []);

--- a/www/FirebaseMessaging.js
+++ b/www/FirebaseMessaging.js
@@ -22,8 +22,8 @@ module.exports = {
     onBackgroundMessage: function(callack, error) {
         exec(callack, error, PLUGIN_NAME, "onBackgroundMessage", []);
     },
-    clearMessages: function(callack, error) {
-        exec(callack, error, PLUGIN_NAME, "clearMessages", []);
+    clearNotifications: function(callack, error) {
+        exec(callack, error, PLUGIN_NAME, "clearNotifications", []);
     },
     revokeToken: function() {
         return new Promise(function(resolve, reject) {


### PR DESCRIPTION
I have written a small method `clearMessages` that removes all notifications from notification center. For my use case, I am calling this method in `onDeviceReady` and `onResume`, so that all app related notifications are cleared when application is launched and/or restored from backgound. I have tested it on both Android and iOS, seems to be working fine. But I have very little experience in Java and Objective C, so please perform a sanity check before accepting the pull. Thank you!