### PR TITLE
ios onMessage and onBackground content_available parameter fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cordova.plugins.firebase.messaging.onMessage(function(payload) {
     console.log("New foreground FCM message: ", payload);
 });
 ```
-NOTE: on iOS make sure notification payload contains key `content-available` with value `1`. Otherwise this callback is never fired.
+NOTE: on iOS make sure notification payload contains key `content_available` with value `true`. Otherwise this callback is never fired.
 
 ### onBackgroundMessage(_callback_)
 Called when a push message received while app is in background.
@@ -78,7 +78,7 @@ cordova.plugins.firebase.messaging.onBackgroundMessage(function(payload) {
     console.log("New background FCM message: ", payload);
 });
 ```
-NOTE: on iOS make sure notification payload contains key `content-available` with value `1`. Otherwise this callback is never fired.
+NOTE: on iOS make sure notification payload contains key `content_available` with value `true`. Otherwise this callback is never fired.
 
 ### requestPermission(_options_)
 Grant permission to recieve push notifications (will trigger prompt on iOS).


### PR DESCRIPTION
The parameter for ios called content_available was misspelled as content-available and the value is a boolean not an integer.
[Firebase endpoint](https://fcm.googleapis.com/fcm/send) returns an error when it is not spelled correctly.