### PR TITLE
Add android:exported attribute to the FirebaseMessagingPluginService

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="by.chemerisuk.cordova.firebase.FirebaseMessagingPluginService">
+            <service android:name="by.chemerisuk.cordova.firebase.FirebaseMessagingPluginService" android:exported="true">
                 <intent-filter>
                     <action android:name="com.google.firebase.MESSAGING_EVENT"/>
                 </intent-filter>

--- a/plugin.xml
+++ b/plugin.xml
@@ -71,7 +71,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="by.chemerisuk.cordova.firebase.FirebaseMessagingPluginService" android:exported="true">
+            <service android:name="by.chemerisuk.cordova.firebase.FirebaseMessagingPluginService" android:exported="false">
                 <intent-filter>
                     <action android:name="com.google.firebase.MESSAGING_EVENT"/>
                 </intent-filter>


### PR DESCRIPTION
Resolve #196 Android 12 and onward it is mandatory to add `android:exported` in the `service` tag in `AndroidManifest.xml`.
Added `android:exported="true"` to the FirebaseMessagingPluginService.