### PR TITLE
Add localbroadcastmanager dependency for Android SDK 34

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,6 +84,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
 
         <dependency id="cordova-support-android-plugin" version="~2.0.4" />
 
+        <framework src="androidx.localbroadcastmanager:localbroadcastmanager:1.1.0" />
         <framework src="platform('com.google.firebase:firebase-bom:$ANDROID_FIREBASE_BOM_VERSION')" />
         <framework src="com.google.firebase:firebase-messaging" />
         <framework src="me.leolin:ShortcutBadger:1.1.22@aar"/>


### PR DESCRIPTION
This adds an explicit dependency on `androidx.localbroadcastmanager`, which seems to be required after upgrading to [Cordova Android 13.0.0](https://cordova.apache.org/announcements/2024/05/23/cordova-android-13.0.0.html), which will shortly be a requirement for Google Play submissions when the minimum target SDK version becomes 34 (Android 14). These were the compile errors we see in our project after upgrading to Cordova Android 13.0.0:

<img width="709" alt="Screenshot 2024-07-16 at 16 50 15" src="https://github.com/user-attachments/assets/7b7da7ec-5b4c-44c5-8780-8c9fba6028ca">

Simply adding the explicit dependency in my local `node_modules/cordova-plugin-firebase-messaging/plugin.xml` and rebuilding the Cordova project fixed the error.