### PR TITLE
Fixes iOS APNS not getting set on repeat boots, adds checkNotificatio…

### DIFF
--- a/src/ios/FirebaseMessagingPlugin.h
+++ b/src/ios/FirebaseMessagingPlugin.h
@@ -15,6 +15,7 @@
 - (void)onMessage:(CDVInvokedUrlCommand*)command;
 - (void)onBackgroundMessage:(CDVInvokedUrlCommand*)command;
 - (void)onTokenRefresh:(CDVInvokedUrlCommand*)command;
+- (void)checkNotificationStatus:(CDVInvokedUrlCommand*)command;
 - (void)sendToken:(NSString*)fcmToken;
 - (void)sendNotification:(NSDictionary*)userInfo;
 - (void)sendBackgroundNotification:(NSDictionary*)userInfo;

--- a/src/ios/FirebaseMessagingPlugin.m
+++ b/src/ios/FirebaseMessagingPlugin.m
@@ -13,6 +13,17 @@
     if(![FIRApp defaultApp]) {
         [FIRApp configure];
     }
+
+    [[UIApplication sharedApplication] registerForRemoteNotifications];
+}
+
+- (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    // Pass device token to Firebase
+    [FIRMessaging messaging].APNSToken = deviceToken;
+}
+
+- (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    NSLog(@"Failed to register for remote notifications: %@", error);
 }
 
 - (void)requestPermission:(CDVInvokedUrlCommand *)command {
@@ -197,4 +208,11 @@
     }
 }
 
+- (void)checkNotificationStatus:(CDVInvokedUrlCommand *)command {
+    UNUserNotificationCenter* notifCenter = [UNUserNotificationCenter currentNotificationCenter];
+    [notifCenter getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
+            CDVPluginResult *pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsInt:(int)settings.authorizationStatus];
+            [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    }];
+}
 @end

--- a/www/FirebaseMessaging.js
+++ b/www/FirebaseMessaging.js
@@ -205,3 +205,17 @@ function(options) {
         exec(resolve, reject, PLUGIN_NAME, "requestPermission", [options || {}]);
     });
 };
+
+
+exports.checkNotificationStatus =
+/**
+ *
+ * Checks and returns a status int on wether or not Push notifications are authorized.
+ * @param {() => void} success Callback function
+ * @param {(error: string) => void} [error] Error callback function
+ */
+function () {
+    return new Promise(function(resolve, reject) {
+        exec(resolve, reject, PLUGIN_NAME, "checkNotificationStatus", []);
+    });
+};


### PR DESCRIPTION
…nStatus function

The changes here include:

**Android:**

- Adds checkNotificationStatus function to get the notifications status `denied/authorized` verdict

**iOS**
- Adds checkNotificationStatus function to get the notifications status `not determined/denied/authorized/provisional/ephemeral` verdict
- Fixes an issue with the APNS Token. On repeat boots the APNS token is set to `nil`